### PR TITLE
Fix indentation at `instance stop` part of the script

### DIFF
--- a/lambda.py
+++ b/lambda.py
@@ -1,12 +1,9 @@
 import boto3
 
-# Does this work?
-# ec2 = boto3.resource('ec2')
-# That may work too... ?
-ec = boto3.client('ec2')
+ec2 = boto3.client('ec2')
 
 def lambda_handler(event, context):
-    reservations = ec.describe_instances(
+    reservations = ec2.describe_instances(
         Filters=[
             {'Name': 'tag-key', 'Values': ['9pmstop']},
         ]
@@ -14,18 +11,17 @@ def lambda_handler(event, context):
         'Reservations', []
     )
 
-    # Is this function only giving you the sum of instances?
+    # use the `sum` function to flatten the list-of-lists-of-instances into a
+    # list of instances
     instances = sum(
         [
-            [i for i in r['Instances']]
-            for r in reservations
+            [instance for instance in reservation['Instances']]
+            for reservation in reservations
         ], [])
 
     print "Found %d instances to be shut down at 9pm" % len(instances)
 
-instance_ids = [ins['InstanceId'] for ins in instances]
-response = ec.stop_instances(InstanceIds=instance_ids)
-print "Stopping %d instances NOW" % len(response['StoppingInstances']
-
-# NOTE: I'd use stronger variable names for better readability.
-# e.g. r['Instances'] -> This doesn't let you know that r is a reservation
+    # pull out all instance IDs from the instance list
+    instance_ids = [ins['InstanceId'] for ins in instances]
+    response = ec2.stop_instances(InstanceIds=instance_ids)
+    print "Stopping %d instances NOW" % len(response['StoppingInstances'])


### PR DESCRIPTION
Also:
- rename boto EC2 client from `ec` to `ec2`
- comment flattening of instance list
- improve variable names
